### PR TITLE
Unit optimizations

### DIFF
--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -11,7 +11,7 @@ public class Spawner : MonoBehaviour
     public Unit unitToSpawn;
 
     // Offset from spawner's position to place spawned unit
-    public Vector3 spawnPositionOffset = new Vector3(0f, 0.1f);
+    private  Vector3 spawnPositionOffset = new Vector3(0f, 0.2f);
 
     // Time remaining until next spawn
     private float timeUntilNextSpawn;
@@ -36,7 +36,7 @@ public class Spawner : MonoBehaviour
                 timeUntilNextSpawn = respawnCooldown + Random.Range(0, .05f);
 
                 // Slightly offset spawn position to prevent units from "stacking"
-                Vector3 randomOffset = new Vector3(Random.Range(-.05f, .05f), Random.Range(-.05f, .05f), 0f);
+                Vector3 randomOffset = new Vector3(Random.Range(-.1f, .1f), Random.Range(-.1f, .1f), 0f);
 
                 Vector3 spawnPosition = this.transform.position + spawnPositionOffset;
                 Unit newUnit = Instantiate(unitToSpawn, spawnPosition, Quaternion.identity);

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -36,7 +36,7 @@ public class Spawner : MonoBehaviour
                 timeUntilNextSpawn = respawnCooldown + Random.Range(0, .05f);
 
                 // Slightly offset spawn position to prevent units from "stacking"
-                Vector3 randomOffset = new Vector3(Random.Range(-.01f, .01f), Random.Range(-.01f, .01f), 0f);
+                Vector3 randomOffset = new Vector3(Random.Range(-.05f, .05f), Random.Range(-.05f, .05f), 0f);
 
                 Vector3 spawnPosition = this.transform.position + spawnPositionOffset;
                 Unit newUnit = Instantiate(unitToSpawn, spawnPosition, Quaternion.identity);

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -33,7 +33,10 @@ public class Spawner : MonoBehaviour
             if (timeUntilNextSpawn <= 0f)
             {
                 // Next spawn time, plus a tiny amount of variance (distributes engine processing load from pre-placed spawners)
-                timeUntilNextSpawn = respawnCooldown + Random.Range(0f, .05f);
+                timeUntilNextSpawn = respawnCooldown + Random.Range(0, .05f);
+
+                // Slightly offset spawn position to prevent units from "stacking"
+                Vector3 randomOffset = new Vector3(Random.Range(-.01f, .01f), Random.Range(-.01f, .01f), 0f);
 
                 Vector3 spawnPosition = this.transform.position + spawnPositionOffset;
                 Unit newUnit = Instantiate(unitToSpawn, spawnPosition, Quaternion.identity);

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -32,7 +32,8 @@ public class Spawner : MonoBehaviour
 
             if (timeUntilNextSpawn <= 0f)
             {
-                timeUntilNextSpawn = respawnCooldown;
+                // Next spawn time, plus a tiny amount of variance (distributes engine processing load from pre-placed spawners)
+                timeUntilNextSpawn = respawnCooldown + Random.Range(0f, .05f);
 
                 Vector3 spawnPosition = this.transform.position + spawnPositionOffset;
                 Unit newUnit = Instantiate(unitToSpawn, spawnPosition, Quaternion.identity);

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -220,6 +220,7 @@ public class Unit : MonoBehaviour
             // bit mask that specifies all layers other than this faction's layer
             int targetLayer = ~(1 << this.gameObject.layer);
 
+            // z depth of units to target (to exclude buildings or ground/flying units)
             float minDepth = float.MinValue;
             float maxDepth = onlyTargetBuildings ? -1f : float.MaxValue;
 
@@ -246,6 +247,7 @@ public class Unit : MonoBehaviour
             {
                 currentTarget = closestTarget;
                 currentSearchRange = (closestTarget.transform.position - this.transform.position).magnitude;
+
                 acquireTargetTimer *= 2; // Delay next target acquisition if this one was successful
             }
             else // If no target found in the search, search a little farther

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -96,6 +96,7 @@ public class Unit : MonoBehaviour
         this.gameObject.layer = LayerMask.NameToLayer(faction.ToString());
     }
 
+    // Sets the z depth for this unit
     void InitializeUnitDepth()
     {
         if (isBuilding) // Buildings have foundations "below ground"

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -209,7 +209,8 @@ public class Unit : MonoBehaviour
 
         if (acquireTargetTimer <= 0f)
         {
-            acquireTargetTimer = acquireTargetCooldown;
+            // Next AcquireTarget time, plus a tiny amount of variance (distributes engine processing load)
+            acquireTargetTimer = acquireTargetCooldown + Random.Range(0f, .25f);
 
             // Get the nearest target that doesn't match this unit's faction and set it as current target
             Unit closestTarget = null;

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -229,7 +229,6 @@ public class Unit : MonoBehaviour
             {
                 Unit unit = visibleColliders[i].gameObject.GetComponent<Unit>();
 
-                //if (IsValidTarget(unit))
                 if (unit)
                 {
                     float distance = (this.transform.position - unit.transform.position).sqrMagnitude;

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -34,7 +34,7 @@ public class Unit : MonoBehaviour
 
     // Timer objects for acquiring a target, so we don't spam it (expensive computation)
     private float acquireTargetTimer = 0f;
-    private float acquireTargetCooldown = .5f;
+    private float acquireTargetCooldown = .25f;
 
     // The current range at which the unit is searching for units
     private float currentSearchRange;
@@ -72,7 +72,7 @@ public class Unit : MonoBehaviour
         if (!spriteRenderer)
             spriteRenderer = this.gameObject.AddComponent<SpriteRenderer>();
 
-        currentSearchRange = visionRange * .125f; // initial range for the unit to search for targets
+        currentSearchRange = visionRange * .25f; // initial range for the unit to search for targets
 
         InitializeUnitFaction();
         InitializeUnitDepth();
@@ -126,6 +126,7 @@ public class Unit : MonoBehaviour
         // If hostile target is in range, attack them
         if (TargetInRange())
         {
+            movementTarget = Vector2.zero; // Stop moving once in range of the target
             FightTarget();
         }
         else
@@ -200,7 +201,7 @@ public class Unit : MonoBehaviour
         return sqrRange >= sqrDistanceToTarget; // check if in range
     }
 
-    Collider2D[] visibleColliders = new Collider2D[250]; // Used to store visible units' colliders when acquiring a target (avoid frequent alloc)
+    Collider2D[] visibleColliders = new Collider2D[100]; // Used to store visible units' colliders when acquiring a target (avoid frequent alloc)
 
     // Acquires a target
     void AcquireTarget()
@@ -210,7 +211,7 @@ public class Unit : MonoBehaviour
         if (acquireTargetTimer <= 0f)
         {
             // Next AcquireTarget time, plus a tiny amount of variance (distributes engine processing load)
-            acquireTargetTimer = acquireTargetCooldown + Random.Range(0f, .25f);
+            acquireTargetTimer = acquireTargetCooldown + Random.Range(0f, .05f);
 
             // Get the nearest target that doesn't match this unit's faction and set it as current target
             Unit closestTarget = null;
@@ -246,10 +247,11 @@ public class Unit : MonoBehaviour
             {
                 currentTarget = closestTarget;
                 currentSearchRange = (closestTarget.transform.position - this.transform.position).magnitude;
+                acquireTargetTimer *= 2; // Delay next target acquisition if this one was successful
             }
             else // If no target found in the search, search a little farther
             {
-                currentSearchRange *= 2;
+                currentSearchRange *= 1.25f;
             }
         }
     }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -257,18 +257,6 @@ public class Unit : MonoBehaviour
         }
     }
 
-    // Check if the given unit is a valid target for this unit
-    protected virtual bool IsValidTarget(Unit target)
-    {
-        if (!target)
-            return false;
-        
-        if (onlyTargetBuildings && !target.isBuilding)
-            return false;
-
-        return true;
-    }
-
     // Fight the current target
     void FightTarget()
     {


### PR DESCRIPTION
- Use z depth when targeting units, for simplicity and efficiency -1 for buildings, 0 for ground, and (in the future) 1 for flying
- Add random time variance to units, and time+position variance to spawners. This distributes engine load better and prevents spawned units from stacking
- tweaked unit target acquisition logic