### PR TITLE
Charm

### DIFF
--- a/Assets/Prefabs/CharmEffectAOE.prefab
+++ b/Assets/Prefabs/CharmEffectAOE.prefab
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1744505893049169504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5389589909268372120}
+  - component: {fileID: 4839006541397892654}
+  m_Layer: 0
+  m_Name: CharmAttackAOE
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5389589909268372120
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744505893049169504}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.7705252, y: 0.38808918, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4839006541397892654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744505893049169504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5dac7757e25119c428357c236520c51f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  radius: 2
+  faction: 1
+  sound:
+    name: 
+    clip: {fileID: 0}
+    source: {fileID: 0}
+    loop: 0
+    mixerGroup: {fileID: 0}
+  duration: 4

--- a/Assets/Prefabs/CharmEffectAOE.prefab.meta
+++ b/Assets/Prefabs/CharmEffectAOE.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 856ce3a99b5e96b47b71265b5d4157de
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ChristopherTest.unity
+++ b/Assets/Scenes/ChristopherTest.unity
@@ -947,6 +947,52 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de6b11bac5cc42646a6178c7cdfde7d8, type: 3}
+--- !u!1 &210372725
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 210372726}
+  - component: {fileID: 210372727}
+  m_Layer: 0
+  m_Name: CharmCard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &210372726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 210372725}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 581.88306, y: 331.5732, z: 2588.8562}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1946048364}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &210372727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 210372725}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b35f40fee41208b49b12702de6507765, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cardName: CharmCard
+  manaCost: 20
+  effect: {fileID: 1396733623}
 --- !u!1 &223750937
 GameObject:
   m_ObjectHideFlags: 0
@@ -2315,7 +2361,7 @@ MonoBehaviour:
   - {fileID: 449784583}
   - {fileID: 269481938}
   - {fileID: 2006609338}
-  - {fileID: 449784583}
+  - {fileID: 210372727}
 --- !u!1001 &427162943
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3067,6 +3113,7 @@ Transform:
   - {fileID: 1779736272}
   - {fileID: 762104231}
   - {fileID: 821726470}
+  - {fileID: 1396733622}
   m_Father: {fileID: 47570706}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4494,7 +4541,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -7.48, y: -18.67}
+  m_AnchoredPosition: {x: -8.84, y: -21.03}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &911208284
@@ -6694,6 +6741,52 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d6efefad91d117d4692d825800f45c6e, type: 3}
+--- !u!1 &1396733621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1396733622}
+  - component: {fileID: 1396733623}
+  m_Layer: 0
+  m_Name: CharmEffect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1396733622
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396733621}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 648955880}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1396733623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396733621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8edd88e6d413de84ab7373dcda9e8bce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  summon: {fileID: 0}
+  areaOfEffectPrefab: {fileID: 4839006541397892654, guid: 856ce3a99b5e96b47b71265b5d4157de,
+    type: 3}
 --- !u!1001 &1402830255
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9282,6 +9375,7 @@ Transform:
   - {fileID: 2006609337}
   - {fileID: 269481937}
   - {fileID: 449784582}
+  - {fileID: 210372726}
   m_Father: {fileID: 47570706}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/CharmAOE.cs
+++ b/Assets/Scripts/CharmAOE.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CharmAOE : AreaOfEffect
+{
+    // Duration of the charm
+    public float duration = 1f;
+
+    // Action for this area of effect
+    protected override void AreaOfEffectAction()
+    {
+        List<Unit> enemiesHit = ComputeEnemyTargets();
+
+        foreach(Unit unit in enemiesHit)
+        {
+            CharmUnitEffect charmUnitEffect = unit.gameObject.AddComponent<CharmUnitEffect>();
+            charmUnitEffect.duration = duration;
+            charmUnitEffect.faction = faction;
+        }
+    }
+}

--- a/Assets/Scripts/CharmAOE.cs.meta
+++ b/Assets/Scripts/CharmAOE.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dac7757e25119c428357c236520c51f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CharmUnitEffect.cs
+++ b/Assets/Scripts/CharmUnitEffect.cs
@@ -11,14 +11,16 @@ public class CharmUnitEffect : UnitEffect
     // What to do at the start of the effect
     protected override void OnEffectStart()
     {
-        // New charm effect overrides any previous hostile charm, or any friendly charm that expires sooner
+        // New charm effect overrides any previous hostile charm, or any same-faction charm that expires sooner
         foreach (CharmUnitEffect charm in unit.gameObject.GetComponents<CharmUnitEffect>())
         {
             if (charm != this)
             {
-                if (charm.faction != this.faction || charm.expirationTime < this.expirationTime)
+                if (charm.faction != this.faction) // Override hostile charm
                     charm.EndEffect();
-                else
+                else if (charm.expirationTime < this.expirationTime) // Override same-faction charm that expires sooner
+                    charm.EndEffect();
+                else // A same-faction charm already lasts longer, this charm effect is unnecessary
                     Destroy(this);
             }
         }

--- a/Assets/Scripts/CharmUnitEffect.cs
+++ b/Assets/Scripts/CharmUnitEffect.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// Charm debuff for a unit
+public class CharmUnitEffect : UnitEffect
+{
+    public Faction faction;
+    private Faction prevFaction;
+
+    // What to do at the start of the effect
+    protected override void OnEffectStart()
+    {
+        // New charm effect overrides any previous hostile charm, or any friendly charm that expires sooner
+        foreach (CharmUnitEffect charm in unit.gameObject.GetComponents<CharmUnitEffect>())
+        {
+            if (charm != this)
+            {
+                if (charm.faction != this.faction || charm.expirationTime < this.expirationTime)
+                    charm.EndEffect();
+                else
+                    Destroy(this);
+            }
+        }
+
+        // Apply charm to target by changing its faction, and the faction of any attached spawners
+        prevFaction = unit.faction;
+        unit.faction = faction;
+        unit.InitializeUnitFaction();
+
+        foreach (Spawner spawner in unit.gameObject.GetComponents<Spawner>())
+            spawner.faction = faction;
+    }
+
+    // What to do at the end of the effect
+    protected override void OnEffectEnd()
+    {
+        // Remove charm from target by restoring its faction
+        unit.faction = prevFaction;
+        unit.InitializeUnitFaction();
+
+        foreach (Spawner spawner in unit.gameObject.GetComponents<Spawner>())
+            spawner.faction = prevFaction;
+    }
+}

--- a/Assets/Scripts/CharmUnitEffect.cs.meta
+++ b/Assets/Scripts/CharmUnitEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 875af8f185c0f584cb4ae466f9572ccb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FlyingUnitEffect.cs
+++ b/Assets/Scripts/FlyingUnitEffect.cs
@@ -22,6 +22,6 @@ public class FlyingUnitEffect : UnitEffect
     {
         // Remove flying from target by setting its z-depth to 0 and resetting its faction layer
         unit.transform.position = new Vector3(unit.transform.position.x, unit.transform.position.y, 0f);
-        unit.InitializeUnitFaction();
+        unit.gameObject.layer = unit.GetFactionLayer();
     }
 }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -89,10 +89,13 @@ public class Unit : MonoBehaviour
                 spriteRenderer.color = Color.red;
             break;
         }
-        this.gameObject.layer = GetFactionLayer();
+
+        // Set faction layer, unless this is a flying unit (they have their own layer)
+        if (this.gameObject.layer != LayerMask.NameToLayer("Flying"))
+            this.gameObject.layer = GetFactionLayer();
     }
 
-    private int GetFactionLayer()
+    public int GetFactionLayer()
     {
         return LayerMask.NameToLayer(faction.ToString());
     }
@@ -125,7 +128,7 @@ public class Unit : MonoBehaviour
         EnableSpawners(); // Enable spawners, in case they were disabled above
 
         // If hostile target is in range, attack them
-        if (TargetInRange())
+        if (currentTarget && currentTarget.faction != this.faction && TargetInRange())
         {
             movementTarget = Vector2.zero; // Stop moving once in range of the target
             FightTarget();

--- a/Assets/Scripts/UnitEffect.cs
+++ b/Assets/Scripts/UnitEffect.cs
@@ -19,7 +19,7 @@ public class UnitEffect : MonoBehaviour
     protected Unit unit;
 
     // Timers for effect expiration, and periodic updates
-    private float expirationTime = 0;
+    protected float expirationTime = 0;
     private float nextPeriodicUpdate = 0;
 
     void Start()


### PR DESCRIPTION
Add an AOE charm spell that temporarily converts units to your faction. This also works on spawners, which temporarily spawn units for your faction instead. A new charm overrides an old charm (unless the old charm had the same faction and lasted longer)